### PR TITLE
Remove OnDemandGroup check

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ module.exports = {
 
 function envCheck() {
   [
-    'OnDemandGroup',
     'INSTANCE_ID',
     'AWS_REGION'
   ].forEach(function(key) {


### PR DESCRIPTION
The OnDemandGroup isn't used by the on-instance `poll.js` function, and I think it can be removed without any negative consequences.

cc/ @arunasank @emilymcafee 