### PR TITLE
Don't timeout for 90s before terminating instance

### DIFF
--- a/bin/poll.js
+++ b/bin/poll.js
@@ -3,6 +3,7 @@
 require('../index').envCheck();
 require('../lib/poll')(
   'http://169.254.169.254/latest/meta-data/spot/termination-time',
+  process.env.terminationTimeout,
   process.env.TerminationOverrideFunction,
   function(err) { if (err) throw err; }
 );

--- a/lib/poll.js
+++ b/lib/poll.js
@@ -20,12 +20,13 @@ module.exports = poll;
  * of terminating the instance
  * @param {Function} callback
  */
-function poll(endpoint, lambdaArn, callback) {
+function poll(endpoint, terminationTimeout, lambdaArn, callback) {
   if (typeof lambdaArn === 'function') {
     callback = lambdaArn;
     lambdaArn = null;
   }
 
+  terminationTimeout = (!terminationTimeout && terminationTimeout !== 0) ? 90 : terminationTimeout;
   AWS.config.update({ region: process.env.AWS_REGION });
   request(endpoint, function(err, res) {
     if (err) return callback(err);
@@ -82,7 +83,7 @@ function poll(endpoint, lambdaArn, callback) {
             InstanceId: process.env.INSTANCE_ID,
             ShouldDecrementDesiredCapacity: false
           }, done);
-        }, 90000);
+        }, process.env.terminationTimeout);
 
       // If the spot instance is in a spot fleet, all we can do is terminate the
       // instance. It is unlikely that this would allow for graceful connection


### PR DESCRIPTION
Let this be handled independently outside of SpotSwap, maybe by a LifeCycleHook operating on each individual EC2. 

cc/ @rclark 